### PR TITLE
Add revision-viewer on the main-view

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -3,6 +3,7 @@ import { Route } from 'react-router-dom';
 
 import ChangesetsViewerContainer from './summaryviewer';
 import DiffViewerContainer from './diffviewer';
+import RevisionSidebar from './revisionsviewer'
 import '../style.css';
 
 const AppDisclaimer = () => (
@@ -41,11 +42,14 @@ export default class App extends Component {
           exact
           path="/"
           render={() => (
-            <div className="changesets-viewer">
-              <AppDisclaimer />
-              <ChangesetsViewerContainer
-                repoName={repoName}
-              />
+            <div>
+              <RevisionSidebar />
+              <div className="changesets-viewer">
+                <AppDisclaimer />
+                <ChangesetsViewerContainer
+                  repoName={repoName}
+                />
+              </div>
             </div>
           )}
         />

--- a/src/components/revisionsviewer.js
+++ b/src/components/revisionsviewer.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import * as FetchAPI from '../fetch_data';
+
+const RevisionListItem = ({revision}) => {
+  // convert timestamp to "YYYY-MM-DDTHH:mm:ss" without using third-party library
+  const convertTime = (s) => {
+    return new Date(s * 1e3).toISOString().slice(0, -5);
+  };
+
+  return (
+    <li>{convertTime(revision[1])} &nbsp; {revision[0]}</li>
+  );
+};
+
+const RevisionList = (props) => {
+   const revisionItems = props.revisions.map((revision) => {
+     return <RevisionListItem key={revision[0]} revision={revision} />
+  });
+
+  return (
+    <ul>
+      {revisionItems}
+    </ul>
+  );
+};
+
+export default class RevisionSidebar extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = { revisions: [["Loading", 0]] }
+
+    FetchAPI.getRevisionNumbers()
+      .then(response => {
+        if (response.status !== 200) {
+          console.log('Error status code' + response.status);
+          return;
+        }
+        response.json().then(res => {
+          // console.log(res);
+          this.setState({ revisions: res.data });
+        });
+      }
+    )
+    .catch(err => {
+      console.log('Fetch error', err);
+    })
+  }
+
+  render() {
+    return (
+      <div className="revision-sidebar">
+        <b>Revision numbers</b>
+        <RevisionList revisions={this.state.revisions} />
+      </div>
+    );
+  }
+}
+
+// export default RevisionSidebar

--- a/src/fetch_data.js
+++ b/src/fetch_data.js
@@ -1,5 +1,8 @@
+import * as Query from './queries';
+
 export const hgHost = 'https://hg.mozilla.org';
 export const ccovBackend = 'https://uplift.shipit.staging.mozilla-releng.net';
+export const activeData = 'http://activedata.allizom.org/query'
 
 const plainHeaders = {
   Accept: 'text/plain',
@@ -19,3 +22,6 @@ export const getChangesetCoverage = changeset =>
 
 export const getChangesetCoverageSummary = changeset =>
   fetch(`${ccovBackend}/coverage/changeset_summary/${changeset}`, { jsonHeaders });
+
+export const getRevisionNumbers = () =>
+  fetch(activeData, { jsonHeaders, method: "POST", body: JSON.stringify(Query.getRevisions) });

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,0 +1,9 @@
+// ActiveDate queries
+
+// https://activedata.allizom.org/tools/query.html#query_id=70sYgySl
+export const getRevisions = {
+  "sort":{"repo.push.date":"desc"},
+  "from":"coverage",
+  "groupby":["repo.changeset.id12","repo.push.date"],
+  "limit":100
+}

--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,16 @@ body {
 	font-size: 12px;
 	margin:20px;
 }
+.changesets-viewer {
+	position: absolute;
+	left: 280px;
+}
+/* revision viewer sidebar */
+.revision-sidebar {
+	position: absolute;
+	width: 200px;
+	border-right: 1px solid;
+}
 /* XXX: The lines inside of pre overrun if the window is very little */
 pre { margin: 0; }
 table.diffblock, th.diffblock, tr.diffblock, td.diffblock {


### PR DESCRIPTION
It can be used as a revision selector.
Currently, the revision numbers inside of a sidebar on the main-view.
The revision info is fetched from ActiveData using query: https://activedata.allizom.org/tools/query.html#query_id=70sYgySl

![screen shot 2017-10-11 at 10 36 52 pm](https://user-images.githubusercontent.com/22087268/31556976-5392a536-b004-11e7-8337-5aeed6e21e8e.png)
