### PR TITLE
Issue #1: The fileviewer now is able to show file contents on the page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -3,6 +3,7 @@ import { Route } from 'react-router-dom';
 
 import ChangesetsViewerContainer from './summaryviewer';
 import DiffViewerContainer from './diffviewer';
+import FileViewerContainer from './fileviewer'
 import '../style.css';
 
 const AppDisclaimer = () => (
@@ -55,6 +56,15 @@ export default class App extends Component {
             <DiffViewerContainer
               changeset={match.params.id}
               repoName={repoName}
+            />
+          )}
+        />
+        <Route
+          path="/revision/:id/:path*"
+          render={({ match }) => (
+            <FileViewerContainer
+              revision={match.params.id}
+              path={match.params.path}
             />
           )}
         />

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -1,15 +1,85 @@
 import React, { Component } from 'react';
 
+import * as FetchAPI from '../fetch_data';
+
 export default class FileViewerContainer extends Component {
-  // console.log(this.props);
+  constructor(props) {
+    super(props);
+    this.state = {
+      appError: undefined,
+      rawFile: undefined,
+    };
+
+    const { revision, path } = this.props;
+    FetchAPI.getRawFile(revision, path)
+      .then(response => {
+        if (response.status !== 200) {
+          console.log('Error status code' + response.status);
+          return;
+        }
+        response.text().then(file => {
+          this.setState({ rawFile: file.split('\n') })
+        });
+      })
+      .catch((error) => {
+        console.error(error);
+        this.setState({
+          appError: 'We did not manage to parse the raw-file correctly.',
+        });
+      });
+  }
+
+
   render() {
-    console.log(this.props);
+    // console.log(this.props);
+    const { revision, path } = this.props;
     return (
       <div>
-        <div>File view</div>
-        <div>revision number: {this.props.revision}</div>
-        <div>path to file: {this.props.path}</div>
+        <FileViewerMeta revision={revision} path={path}/>
+        <FileViewer rawFile={this.state.rawFile} />
       </div>
     );
   }
 }
+
+
+
+/* This viewer renders each line of the file with its line number */
+const FileViewer = ({ rawFile }) => {
+  if (!rawFile) {
+    return( <div>"Waiting for file from the backend"</div> );
+  }
+
+  var id = 0;
+  const rawFileLines = rawFile.map((line) => {
+    id = id + 1;
+    return(
+      <tr key={id}>
+        <th>{id}</th>
+        <th>{line}</th>
+      </tr>
+    );
+  });
+
+  return (
+    <div>
+      <table className="table table-sm table-bordered table-hover">
+        <tbody>
+          {rawFileLines}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+
+
+
+/* This view contains meta data of the file */
+const FileViewerMeta = ({ revision, path }) => {
+  return (
+    <h4>
+      Revision number: {revision} <br/> Path: {path}
+    </h4>
+  );
+};

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+
+export default class FileViewerContainer extends Component {
+  // console.log(this.props);
+  render() {
+    console.log(this.props);
+    return (
+      <div>
+        <div>File view</div>
+        <div>revision number: {this.props.revision}</div>
+        <div>path to file: {this.props.path}</div>
+      </div>
+    );
+  }
+}

--- a/src/fetch_data.js
+++ b/src/fetch_data.js
@@ -19,3 +19,7 @@ export const getChangesetCoverage = changeset =>
 
 export const getChangesetCoverageSummary = changeset =>
   fetch(`${ccovBackend}/coverage/changeset_summary/${changeset}`, { jsonHeaders });
+
+// raw-file fetcher (fileviewer)
+export const getRawFile = (revision, path) =>
+  fetch(`${hgHost}/integration/mozilla-inbound/raw-file/${revision}/${path}`, { plainHeaders });


### PR DESCRIPTION
Given revision-number and the path, the fileviewer is able to fetch the sources from hg, and displays it on the fileview.

E.x  Request following URL in browser (http://localhost:3000/#/revision/6b0491f83229/accessible/atk/Platform.cpp)