### PR TITLE
Add query-string to DiffViewer

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -50,17 +50,13 @@ export default class App extends Component {
           )}
         />
         <Route
-          path="/changeset/:id"
-          render={({ match }) => (
+          path="/diff"
+          render={({location}) => (
             <DiffViewerContainer
-              changeset={match.params.id}
               repoName={repoName}
+              location={location}
             />
           )}
-        />
-        <Route
-          path="/diff"
-          component={DiffViewerContainer}
         />
       </div>
     );

--- a/src/components/diffviewer.js
+++ b/src/components/diffviewer.js
@@ -23,17 +23,12 @@ export default class DiffViewerContainer extends Component {
   }
 
   componentDidMount() {
-    let changeset=undefined;
-    if (this.props.changeset) {
-      changeset = this.props.changeset;
-    } else {
-      /* get revision and path parameters from URL */
-      const parsedQuery = queryString.parse(this.props.location.search);
-      if (!parsedQuery.changeset) {
-        this.setState({appError: "Undefined URL query ('revision', 'path' fields are required)"});
-      }
-      changeset = parsedQuery.changeset
+    /* get revision and path parameters from URL */
+    const parsedQuery = queryString.parse(this.props.location.search);
+    if (!parsedQuery.changeset) {
+      this.setState({appError: "Undefined URL query ('changeset' field is required)"});
     }
+    const changeset = parsedQuery.changeset;
 
     FetchAPI.getDiff(changeset)
       .then(response =>

--- a/src/components/summaryviewer.js
+++ b/src/components/summaryviewer.js
@@ -15,7 +15,7 @@ const ChangesetInfo = ({ changeset, push }) => {
         {author.substring(0, 22)}</td>
       <td className="changeset-node-id">
         {(linkify) ?
-          <Link to={`/changeset/${node}`}>{node.substring(0, 12)}</Link>
+          <Link to={`/diff?changeset=${node}`}>{node.substring(0, 12)}</Link>
           : <span>{node.substring(0, 12)}</span>}
       </td>
       <td className="changeset-description">

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { HashRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import App from './components/app';
 
 ReactDOM.render(
-  <HashRouter><App /></HashRouter>,
+  <BrowserRouter><App /></BrowserRouter>,
   document.getElementById('root'),
 );


### PR DESCRIPTION
Refer to https://github.com/armenzg/firefox-code-coverage-frontend/issues/58
Sorry for the late PR, it has been a busy week. 
Here is a fix to the diffViewer router.

I changed the Armen's implementation of diffViewer router, because in order to remove the "#/" from URL, we have to use "BrowserRouter" instead of "HashRouter". So, the old URL(https://firefox-code-coverage.herokuapp.com/#/changeset/b2232cf95183b220c1918798e615a3591724f5c8) won't work anymore

Try new URL: http://localhost:3000/diff?changeset=64496ef98f774c8bce7283923cd5311dd54faeca

```
ReactDOM.render(
-  <HashRouter><App /></HashRouter>,
+  <BrowserRouter><App /></BrowserRouter>,
   document.getElementById('root'),
```
