### PR TITLE
Issue #11: Show coverage percentage of a file

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "form-serialize": "^0.7.2",
+    "lodash": "^4.17.4",
     "parse-diff": "^0.4.0",
     "prop-types": "^15.6.0",
     "query-string": "^5.0.1",

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -172,19 +172,29 @@ const FileViewerMeta = ({ revision, path, appError }) => {
 };
 
 const CoverageMeta = ({ coverage }) => {
+  // if there is no coverage information, then do not display the percentage covered
   let percentageCovered = undefined;
   
   if (coverage) {
-    let total_covered = _.union(_.flatten(coverage.data.map((d) => d.source.file.covered)));
+    let totalCovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.covered)));
     let uncovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.uncovered)));
-    let total_uncovered = _.difference(uncovered, total_covered);
-    this.percentageCovered = total_covered.length / total_uncovered.length;
+    let totalUncovered = _.difference(uncovered, totalCovered);
+    // if there is coverage information and no lines are uncovered, percentage covered is 100%
+    if (totalCovered.length > 0 && totalUncovered.length === 0) {
+      this.percentageCovered = 1;
+    }
+    // calculate the percentage covered if there is coverage information
+    if (!(totalCovered === 0 && uncovered === 0)) {
+      this.percentageCovered = totalCovered.length / totalUncovered.length;
+    }
   }
 
   return (
     <div className="coverage_meta">
       <div className="coverage_meta_totals">
-        <span className="percentage_covered">{(this.percentageCovered * 100).toPrecision(4)}%</span>
+        {this.percentageCovered && 
+          <span className="percentage_covered">{(this.percentageCovered * 100).toPrecision(4)}%</span>
+        }
       </div>
     </div>
   );

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -179,7 +179,7 @@ const CoverageMeta = ({ coverage }) => {
     let uncovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.uncovered)));
     let totalLines = _.union(uncovered, totalCovered).length;
 
-    if (totalCovered !== 0 && uncovered !== 0) {
+    if (totalCovered !== 0 || uncovered !== 0) {
       this.percentageCovered = totalCovered.length / totalLines;
     } else {
       //this.percentageCovered is left undefined

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -49,23 +49,27 @@ export default class FileViewerContainer extends Component {
       "format": "list"
     })
     .then(data => {
-      this.setState({coverage: data});
-      // TODO remove these log lines
       console.log(data);
+      this.setState({coverage: data});
     });
   }
 
   render() {
+    const { appError, coverage, parsedFile } = this.state;
+
     return (
       <div>
         <FileViewerMeta
           revision={this.revision}
           path={this.path}
-          appError={this.state.appError}
+          appError={appError}
+        />
+        <CoverageMeta 
+          coverage={coverage}
         />
         <FileViewer
-          parsedFile={this.state.parsedFile}
-          coverage={this.state.coverage}
+          parsedFile={parsedFile}
+          coverage={coverage}
         />
       </div>
     );
@@ -108,6 +112,30 @@ const FileViewerMeta = ({ revision, path, appError }) => {
     <div>
       {appError && <span className="error_message">{appError}</span>}
       <h4>Revision number: {revision} <br/> Path: {path}</h4>
+    </div>
+  );
+};
+
+const CoverageMeta = ({ coverage }) => {
+  let [percentageCovered, totalCovered, totalUncovered] = [undefined, undefined, undefined];
+
+  if (coverage) {
+    /* TODO Currently showing coverage totals for one particular test:
+     * test-linux64-ccov/opt-web-platform-tests-1.
+     * In the future, test will be passed as a prop. */
+    const test = coverage.data[0].source.file;
+    this.percentageCovered=(test.percentage_covered * 100).toPrecision(4);
+    this.totalCovered=test.total_covered;
+    this.totalUncovered=test.total_uncovered; 
+  }
+
+  return (
+    <div className="coverage_meta">
+      <div className="coverage_meta_totals">
+        <span className="totals percentage_covered">{this.percentageCovered}%</span>
+        <span className="totals total_covered">{this.totalCovered}</span>
+        <span className="totals total_uncovered">{this.totalUncovered}</span>
+      </div>
     </div>
   );
 };

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import * as FetchAPI from '../fetch_data';
 
 const queryString = require('query-string');
+const _ = require('lodash')
 
 /* FileViewer loads a raw file for a given revision from Mozilla's hg web.
  * It uses test coverage information from Active Data to show coverage
@@ -117,24 +118,19 @@ const FileViewerMeta = ({ revision, path, appError }) => {
 };
 
 const CoverageMeta = ({ coverage }) => {
-  let [percentageCovered, totalCovered, totalUncovered] = [undefined, undefined, undefined];
-
+  let percentageCovered = undefined;
+  
   if (coverage) {
-    /* TODO Currently showing coverage totals for one particular test:
-     * test-linux64-ccov/opt-web-platform-tests-1.
-     * In the future, test will be passed as a prop. */
-    const test = coverage.data[0].source.file;
-    this.percentageCovered=(test.percentage_covered * 100).toPrecision(4);
-    this.totalCovered=test.total_covered;
-    this.totalUncovered=test.total_uncovered; 
+    let total_covered = _.union(_.flatten(coverage.data.map((d) => d.source.file.covered)));
+    let uncovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.uncovered)));
+    let total_uncovered = _.difference(uncovered, total_covered);
+    this.percentageCovered = total_covered.length / total_uncovered.length;
   }
 
   return (
     <div className="coverage_meta">
       <div className="coverage_meta_totals">
-        <span className="totals percentage_covered">{this.percentageCovered}%</span>
-        <span className="totals total_covered">{this.totalCovered}</span>
-        <span className="totals total_uncovered">{this.totalUncovered}</span>
+        <span className="percentage_covered">{(this.percentageCovered * 100).toPrecision(4)}%</span>
       </div>
     </div>
   );

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -172,20 +172,17 @@ const FileViewerMeta = ({ revision, path, appError }) => {
 };
 
 const CoverageMeta = ({ coverage }) => {
-  // if there is no coverage information, then do not display the percentage covered
   let percentageCovered = undefined;
   
   if (coverage) {
     let totalCovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.covered)));
     let uncovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.uncovered)));
-    let totalUncovered = _.difference(uncovered, totalCovered);
-    // if there is coverage information and no lines are uncovered, percentage covered is 100%
-    if (totalCovered.length > 0 && totalUncovered.length === 0) {
-      this.percentageCovered = 1;
-    }
-    // calculate the percentage covered if there is coverage information
-    if (!(totalCovered === 0 && uncovered === 0)) {
-      this.percentageCovered = totalCovered.length / totalUncovered.length;
+    let totalLines = _.union(uncovered, totalCovered).length;
+
+    if (totalCovered !== 0 && uncovered !== 0) {
+      this.percentageCovered = totalCovered.length / totalLines;
+    } else {
+      //this.percentageCovered is left undefined
     }
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -93,7 +93,7 @@ div.coverage_meta_totals {
 	float: right;
 }
 
-span.totals {
+span.percentage_covered {
 	border-radius: 0.25rem;
 	color: rgb(255, 255, 255);
 	font-size: 1em;
@@ -102,16 +102,5 @@ span.totals {
 	padding-bottom: 0.6em;
 	padding-left: 0.8em;
 	margin: 0.05em;
-}
-
-span.percentage_covered {
 	background-color: #f071b0;
-}
-
-span.total_covered {
-	background-color: #6bff7d;
-}	
-
-span.total_uncovered {
-	background-color: #f76161;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -78,3 +78,40 @@ td.new_line_number, td.old_line_number {
 	color: #85878c;
 	padding: 1px;
 }
+
+div.coverage_meta {
+	height: 3.8em;
+}
+
+div.coverage_meta_totals {
+	border: 1px solid #d4d4d5;
+	border-radius: 0.20rem;
+	padding-top: 1.0em;
+	padding-right: 0.3em;
+	padding-bottom: 1.0em;
+	padding-left: 0.3em;
+	float: right;
+}
+
+span.totals {
+	border-radius: 0.25rem;
+	color: rgb(255, 255, 255);
+	font-size: 1em;
+	padding-top: 0.6em;
+	padding-right: 0.8em;
+	padding-bottom: 0.6em;
+	padding-left: 0.8em;
+	margin: 0.05em;
+}
+
+span.percentage_covered {
+	background-color: #f071b0;
+}
+
+span.total_covered {
+	background-color: #6bff7d;
+}	
+
+span.total_uncovered {
+	background-color: #f76161;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6475,6 +6475,10 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+underscore@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"


### PR DESCRIPTION
Issue: #11. This is showing the coverage totals (percentage covered, total lines covered, total lines uncovered) for one particular test: test-linux64-ccov/opt-web-platform-tests-1.  In the future, test will be passed as a prop.  Preview with http://localhost:3000/file?revision=a0334f789772&path=/accessible/atk/Platform.cpp.

<img width="903" alt="screen shot 2017-11-03 at 1 09 26 am" src="https://user-images.githubusercontent.com/14918664/32363373-b40ff4c8-c034-11e7-8543-1e5294b93ce2.png">
