### PR TITLE
fix lint errors and others

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -3,7 +3,7 @@ import { Route } from 'react-router-dom';
 
 import ChangesetsViewerContainer from './summaryviewer';
 import DiffViewerContainer from './diffviewer';
-import FileViewerContainer from './fileviewer'
+import FileViewerContainer from './fileviewer';
 import '../style.css';
 
 const AppDisclaimer = () => (

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -80,7 +80,9 @@ export default class FileViewerContainer extends Component {
         }
         testsPerHitLine[line].push(d);
       });
+    });
 
+    data.forEach((d) => {
       d.source.file.uncovered.forEach((line) => {
         if (!testsPerHitLine[line]) {
           uncovered.push(line);
@@ -90,7 +92,7 @@ export default class FileViewerContainer extends Component {
           testsPerMissLine[line].push(d);
         }
       });
-    });
+    })
 
     this.setState({
       coverage: {

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
 
 import * as FetchAPI from '../fetch_data';
-import { TestsSideViewer } from './fileviewercov';
+import { TestsSideViewer, CoveragePercentageViewer } from './fileviewercov';
 
 const queryString = require('query-string');
-const _ = require('lodash')
 
 /* FileViewer loads a raw file for a given revision from Mozilla's hg web.
  * It uses test coverage information from Active Data to show coverage
@@ -17,82 +16,52 @@ export default class FileViewerContainer extends Component {
       appError: undefined,
       coverage: undefined,
       parsedFile: [],
-      selectedLine: null,
-      testsPerLines: undefined,
+      selectedLine: undefined,
     };
-
-    this.setSelectedLine = this.setSelectedLine.bind(this)
-  }
-
-  componentDidMount() {
+    this.setSelectedLine = this.setSelectedLine.bind(this);
     /* get revision and path parameters from URL */
-    const parsedQuery = queryString.parse(this.props.location.search);
+    const parsedQuery = queryString.parse(props.location.search);
     if (!parsedQuery.revision || !parsedQuery.path) {
       this.setState({ appError: "Undefined URL query ('revision', 'path' fields are required)" });
     }
-    /* remove begining '/' in the path parameter */
+    /* remove beginning '/' in the path parameter */
     if (parsedQuery.path.startsWith('/')) {
       parsedQuery.path = parsedQuery.path.slice(1);
     }
-    this.revision = parsedQuery.revision
-    this.path = parsedQuery.path
+    this.revision = parsedQuery.revision;
+    this.path = parsedQuery.path;
+  }
 
+  componentDidMount() {
     /* Fetch source code from hg */
     FetchAPI.getRawFile(this.revision, this.path)
-      .then(text => this.setState({ parsedFile: text.split("\n") }))
+      .then(text => this.setState({ parsedFile: text.split('\n') }))
     ;
 
     /* Fetch coverages from ActiveData */
     FetchAPI.query({
-      "from": "coverage",
-      "where": {
-        "and": [
-          {"eq": {"source.file.name": `${this.path}`}},
-          {"eq": {"repo.changeset.id12": `${this.revision}`}}
-        ]
+      from: 'coverage',
+      where: {
+        and: [
+          { eq: { 'source.file.name': `${this.path}` } },
+          { eq: { 'repo.changeset.id12': `${this.revision}` } },
+        ],
       },
-      "limit": 1000,
-      "format": "list"
+      limit: 1000,
+      format: 'list',
     })
-    .then(data => {
-      console.log(data);
-      this.setState({coverage: data});
-      this.parseTestsCoverage(data.data);
-    });
-  }
-
-  /* Parse data returns from ActiveData */
-  parseTestsCoverage(data) {
-    console.log(data.length);
-    var stat = []
-
-    data.forEach(d => {
-      const coveredLines = d.source.file.covered;
-      coveredLines.forEach(line => {
-        if (!stat[line]) {
-          stat[line] = [];
-        }
-        stat[line].push(d);
+      .then((data) => {
+        this.setState({ coverage: data });
       });
-    });
-
-    console.log(stat);
-    this.setState({testsPerLines: stat});
   }
 
   /* handle fileviewer's line onclick event */
-  setSelectedLine(lineNumber) {
-    console.log(lineNumber);
-    this.setState({selectedLine: lineNumber});
-    // if (this.state.selectedLine == lineNumber) {
-    //   this.setState({selectedLine: null})
-    // } else {
-    //   this.setState({selectedLine: lineNumber});
-    // }
+  setSelectedLine(selectedLineNumber) {
+    this.setState({ selectedLine: selectedLineNumber });
   }
 
   render() {
-    const { appError, coverage, parsedFile } = this.state;
+    const { appError, coverage, parsedFile, selectedLine } = this.state;
 
     return (
       <div>
@@ -101,98 +70,62 @@ export default class FileViewerContainer extends Component {
           path={this.path}
           appError={appError}
         />
-        <CoverageMeta 
+        <CoveragePercentageViewer
           coverage={coverage}
         />
         <FileViewer
-          parsedFile={this.state.parsedFile}
-          testsPerLines={this.state.testsPerLines}
+          parsedFile={parsedFile}
           onLineClick={this.setSelectedLine}
-          selectedLine={this.state.selectedLine}
         />
         <TestsSideViewer
-          testsPerLines={this.state.testsPerLines}
-          selectedLine={this.state.selectedLine}
+          coverage={coverage}
+          lineNumber={selectedLine}
         />
       </div>
     );
-  };
+  }
 }
 
 /* This component renders each line of the file with its line number */
-const FileViewer = ({ parsedFile, testsPerLines, onLineClick, selectedLine }) => {
-  return (
-    <div>
-      <table>
-        <tbody>
-          {
-            parsedFile.map((line, lineNumber) => (
-              <Line
-                key={lineNumber}
-                lineNumber={lineNumber+1}
-                lineText={line}
-                onLineClick={onLineClick}
-                selectedLine={selectedLine}
-              />
-            ))
-          }
-        </tbody>
-      </table>
-    </div>
-  );
-};
+const FileViewer = ({ parsedFile, onLineClick }) => (
+  <div>
+    <table>
+      <tbody>
+        {
+          parsedFile.map((line, lineNumber) => (
+            <Line
+              key={lineNumber}
+              lineNumber={lineNumber + 1}
+              lineText={line}
+              onLineClick={onLineClick}
+            />
+          ))
+        }
+      </tbody>
+    </table>
+  </div>
+);
 
 const Line = (props) => {
-  const handleOnClick = () => {
-    props.onLineClick(props.lineNumber);
-  }
+  let lineClass = '';
 
-  let lineClass = "";
-  if (props.selectedLine === props.lineNumber ) {
-    lineClass = "selected"
-  }
+  const handleOnClick = () => {
+    lineClass = 'selected';
+    props.onLineClick(props.lineNumber);
+  };
 
   return (
-      <tr>
-        <td className="file_line_number">{props.lineNumber}</td>
-        <td className={`file_line_text ${lineClass}`} onClick={handleOnClick}><pre>{props.lineText}</pre></td>
-      </tr>
+    <tr>
+      <td className="file_line_number">{props.lineNumber}</td>
+      <td className={`file_line_text ${lineClass}`} onClick={handleOnClick}><pre>{props.lineText}</pre></td>
+    </tr>
   );
 };
-
 
 /* This component contains metadata of the file */
-const FileViewerMeta = ({ revision, path, appError }) => {
-  return (
-    <div>
-      {appError && <span className="error_message">{appError}</span>}
-      <h4>Revision number: {revision} <br/> Path: {path}</h4>
-    </div>
-  );
-};
-
-const CoverageMeta = ({ coverage }) => {
-  let percentageCovered = undefined;
-  
-  if (coverage) {
-    let totalCovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.covered)));
-    let uncovered = _.union(_.flatten(coverage.data.map((d) => d.source.file.uncovered)));
-    let totalLines = _.union(uncovered, totalCovered).length;
-
-    if (totalCovered !== 0 || uncovered !== 0) {
-      this.percentageCovered = totalCovered.length / totalLines;
-    } else {
-      //this.percentageCovered is left undefined
-    }
-  }
-
-  return (
-    <div className="coverage_meta">
-      <div className="coverage_meta_totals">
-        {this.percentageCovered && 
-          <span className="percentage_covered">{(this.percentageCovered * 100).toPrecision(4)}%</span>
-        }
-      </div>
-    </div>
-  );
-};
+const FileViewerMeta = ({ revision, path, appError }) => (
+  <div>
+    {appError && <span className="error_message">{appError}</span>}
+    <h4>Revision number: {revision} <br /> Path: {path}</h4>
+  </div>
+);

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -80,11 +80,13 @@ export default class FileViewerContainer extends Component {
         }
         testsPerHitLine[line].push(d);
       });
+
       d.source.file.uncovered.forEach((line) => {
-        uncovered.push(line);
-        if (!testsPerMissLine[line]) {
-          testsPerMissLine[line] = [];
-        } else {
+        if (!testsPerHitLine[line]) {
+          uncovered.push(line);
+          if (!testsPerMissLine[line]) {
+            testsPerMissLine[line] = [];
+          }
           testsPerMissLine[line].push(d);
         }
       });

--- a/src/components/fileviewercov.js
+++ b/src/components/fileviewercov.js
@@ -1,52 +1,75 @@
-/* This file contains file-view RHS siderbar components */
-
+/* This file contains coverage information for a particular revision of a source file */
 import React from 'react';
 
+const _ = require('lodash');
+
 /* Sidebar component, show which tests will cover the given selected line */
-export const TestsSideViewer = ({testsPerLines, selectedLine}) => {
+export const TestsSideViewer = ({ coverage, lineNumber }) => {
+  let content;
 
-  if (!testsPerLines) {
-    return (
-      <div className="tests_viewer">
-        <h3>"Fetching coverage from backend..."</h3>
-      </div>
-    );
+  if (!coverage) {
+    content = <h3>Fetching coverage from backend...</h3>;
+  } else if (!lineNumber) {
+    // TODO if no line has been selected, show coverage of the file
+    content = <h3>Select a line to view tests</h3>;
+  } else {
+    /* Parse coverage data returned from ActiveData to get the tests for a line */
+    const testThatCover = coverage.data.filter(d => d.source.file.covered.find(line => line === lineNumber));
+    if (testThatCover.length > 0) {
+      content = (
+        <div>
+          <h3>Line: {lineNumber}</h3>
+          <ul>
+            {
+              testThatCover.map(test =>
+                (<Test
+                  key={test.run.name}
+                  name={test.run.name}
+                />),
+              )
+            }
+          </ul>
+        </div>
+      );
+    } else {
+      content = (
+        <div className="tests_viewer">
+          <h3>Line: {lineNumber}</h3>
+          <p>No test covers this line</p>
+        </div>
+      );
+    }
   }
+  return <div className="tests_viewer">{content}</div>;
+};
 
-  // TODO if no line has been selected, show coverage of the file
-  else if (!selectedLine) {
-    return (
-      <div className="tests_viewer">
-        <h3>Select a line to view tests</h3>
-      </div>
-    );
+const Test = props => <li>{props.name}</li>;
+
+/* shows coverage percentage of a file */
+export const CoveragePercentageViewer = ({ coverage }) => {
+  const percentageCovered = undefined;
+
+  if (coverage) {
+    const totalCovered = _.union(_.flatten(coverage.data.map(d => d.source.file.covered)));
+    const uncovered = _.union(_.flatten(coverage.data.map(d => d.source.file.uncovered)));
+    const totalLines = _.union(uncovered, totalCovered).length;
+
+    if (totalCovered !== 0 || uncovered !== 0) {
+      this.percentageCovered = totalCovered.length / totalLines;
+    } else {
+      // this.percentageCovered is left undefined
+    }
   }
 
   return (
-    <div className="tests_viewer">
-      <h3>Line: {selectedLine}</h3>
-      <TestsDetail
-        testsPerLines={testsPerLines}
-        selectedLine={selectedLine}
-      />
+    <div className="coverage_meta">
+      <div className="coverage_meta_totals">
+        {this.percentageCovered &&
+          <span className="percentage_covered">
+            {(this.percentageCovered * 100).toPrecision(4)}%
+          </span>
+        }
+      </div>
     </div>
   );
 };
-
-/* Sidebar list component*/
-const TestsDetail = ({testsPerLines, selectedLine}) => {
-  const testList = testsPerLines[selectedLine];
-    if (!testList) {
-      return <div>No test covers this line</div>
-    }
-
-  const testItems = testList.map((test) => {
-    return <li key={test.run.name}>{test.run.name}</li>
-  });
-
-  return (
-    <ul>
-      {testItems}
-    </ul>
-  );
-}

--- a/src/components/fileviewercov.js
+++ b/src/components/fileviewercov.js
@@ -46,7 +46,7 @@ export const CoveragePercentageViewer = ({ coverage }) => {
   const percentageCovered = undefined;
 
   if (coverage) {
-    const totalLines = _.union(coverage.uncoveredLines, coverage.coveredLines).length;
+    const totalLines = coverage.uncoveredLines.length + coverage.coveredLines.length;
 
     if (coverage.coveredLines.length !== 0 || coverage.uncoveredLines.length !== 0) {
       this.percentageCovered = coverage.coveredLines.length / totalLines;

--- a/src/components/fileviewercov.js
+++ b/src/components/fileviewercov.js
@@ -4,21 +4,21 @@ import React from 'react';
 const _ = require('lodash');
 
 /* Sidebar component, show which tests will cover the given selected line */
-export const TestsSideViewer = ({ lineNumber, testsPerLines }) => {
+export const TestsSideViewer = ({ coverage, lineNumber }) => {
   let content;
 
-  if (!testsPerLines) {
+  if (!coverage) {
     content = <h3>Fetching coverage from backend...</h3>;
   } else if (!lineNumber) {
     // TODO if no line has been selected, show coverage of the file
     content = <h3>Select a line to view tests</h3>;
-  } else if (testsPerLines[lineNumber] && testsPerLines[lineNumber].length > 0) {
+  } else if (coverage.testsPerHitLine[lineNumber]) {
     content = (
       <div>
         <h3>Line: {lineNumber}</h3>
         <ul>
           {
-            testsPerLines[lineNumber].map(test =>
+            coverage.testsPerHitLine[lineNumber].map(test =>
               (<Test
                 key={test.run.name}
                 name={test.run.name}
@@ -46,12 +46,10 @@ export const CoveragePercentageViewer = ({ coverage }) => {
   const percentageCovered = undefined;
 
   if (coverage) {
-    const totalCovered = _.union(_.flatten(coverage.data.map(d => d.source.file.covered)));
-    const uncovered = _.union(_.flatten(coverage.data.map(d => d.source.file.uncovered)));
-    const totalLines = _.union(uncovered, totalCovered).length;
+    const totalLines = _.union(coverage.uncoveredLines, coverage.coveredLines).length;
 
-    if (totalCovered !== 0 || uncovered !== 0) {
-      this.percentageCovered = totalCovered.length / totalLines;
+    if (coverage.coveredLines.length !== 0 || coverage.uncoveredLines.length !== 0) {
+      this.percentageCovered = coverage.coveredLines.length / totalLines;
     } else {
       // this.percentageCovered is left undefined
     }

--- a/src/fetch_data.js
+++ b/src/fetch_data.js
@@ -9,6 +9,39 @@ const jsonHeaders = {
   Accept: 'application/json',
 };
 
+export const httpFetch = params =>
+  fetch(
+    params.url,
+    {
+      headers: params.headers || plainHeaders,
+      method: params.method || 'GET',
+      body: params.body,
+    },
+  )
+    .then((response) => {
+      if (response.status !== 200) {
+        throw Error(`Error status code${response.status}`);
+      }
+      return response.text();
+    })
+    .catch((error) => {
+      throw Error(`Problem fetching from URL${error}`);
+    })
+;
+
+export const jsonPost = params =>
+  httpFetch({
+    url: params.url,
+    headers: jsonHeaders,
+    method: 'POST',
+    body: JSON.stringify(params.body),
+  })
+    .then(response => JSON.parse(response))
+    .catch((error) => {
+      throw Error(`Problem fetching JSON from URL ${params.url}\n${error}`);
+    })
+;
+
 export const getDiff = changeset =>
   fetch(`${hgHost}/mozilla-central/raw-rev/${changeset}`, { plainHeaders });
 
@@ -23,44 +56,11 @@ export const getChangesetCoverageSummary = changeset =>
 
 // raw-file fetcher (fileviewer)
 export const getRawFile = (revision, path) => httpFetch({
-  url: `${hgHost}/integration/mozilla-inbound/raw-file/${revision}/${path}`
+  url: `${hgHost}/integration/mozilla-inbound/raw-file/${revision}/${path}`,
 });
 
 // query active data
-export const query = (query) => jsonPost({
+export const query = body => jsonPost({
   url: `${activeData}/query`,
-  body: query
+  body,
 });
-
-export const jsonPost = (params) =>
-  httpFetch({
-    url: params.url,
-    headers: jsonHeaders,
-    method: "POST",
-    body: JSON.stringify(params.body)
-  })
-  .then(response => JSON.parse(response))
-  .catch(error => {
-    throw Error('Problem fetching JSON from URL ' + params.url + "\n" + error);
-  })
-;
-
-export const httpFetch = (params) =>
-  fetch(
-    params.url,
-    {
-      headers: params.headers || plainHeaders,
-      method: params.method || "GET",
-      body: params.body
-    }
-  )
-  .then(response => {
-    if (response.status !== 200) {
-      throw Error('Error status code' + response.status);
-    }
-    return response.text();
-  })
-  .catch(error => {
-    throw Error('Problem fetching from URL' + error);
-  })
-;

--- a/src/style.css
+++ b/src/style.css
@@ -152,7 +152,7 @@ div.coverage_meta_totals {
 
 span.percentage_covered {
 	border-radius: 0.25rem;
-	color: rgb(255, 255, 255);
+	color: rgb(0, 0, 0);
 	font-size: 1em;
 	padding-top: 0.6em;
 	padding-right: 0.8em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6475,10 +6475,6 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
-underscore@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"


### PR DESCRIPTION
Lint error corrections. 
The other main difference is originally a hash map was used to store line numbers to data containing tests. While this method avoids recalculations of tests belonging to a line, I felt that the FileViewerContainer was growing too large with too many states, and I am unsure about constructing the hash table in the fetch call itself.  This change includes moving the tests extraction into the TestsSideViewer component.  
const testThatCover = coverage.data.filter(d => d.source.file.covered.find(line => line === lineNumber)) replaces the parseTestsCoverage function.  One is retrieving the tests on the fly and one is performing a one time calculation of the tests that belongs to each line and storing it in a hash map.   
Would like Linkai and Kyle's input on this.