### PR TITLE
Darken covered lines based on the number of tests that cover

### DIFF
--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import * as FetchAPI from '../fetch_data';
+import * as Color from '../utils/color';
 import { TestsSideViewer, CoveragePercentageViewer } from './fileviewercov';
 
 const queryString = require('query-string');
@@ -19,6 +20,7 @@ export default class FileViewerContainer extends Component {
       coverage: {
         coveredLines: [],
         uncoveredLines: [],
+        allTests: [],
         testsPerHitLine: [],
         testsPerMissLine: [],
       },
@@ -98,6 +100,7 @@ export default class FileViewerContainer extends Component {
       coverage: {
         coveredLines: _.uniq(covered),
         uncoveredLines: _.uniq(uncovered),
+        allTests: data,
         testsPerHitLine,
         testsPerMissLine,
       },
@@ -170,8 +173,16 @@ const Line = (props) => {
     }
   }
 
+  // default line color
+  let color = '#ffffff';
+  if (nTests) {
+    // normalize nTest to a score between 0 and 1 where 1 is the maximum number of tests
+    const nTestNorm = nTests / props.coverage.allTests.length;
+    color = Color.getLineHitCovColor(nTestNorm);
+  }
+
   return (
-    <tr className={`file_line ${coverage} ${lineClass}`}>
+    <tr className={`file_line ${lineClass}`} style={{ backgroundColor: `${color}` }}>
       <td className="file_line_number">{props.lineNumber}</td>
       <td className="file_line_tests">
         { coverage === 'hit' && <span className="tests">{nTests}</span> }

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,3 +1,5 @@
 const chroma = require('chroma-js');
 
 export const getPercentCovColor = percent => chroma.scale(['red', 'yellow', 'green']).mode('lab')(percent);
+
+export const getLineHitCovColor = percent => chroma.scale(['dfd', 'a1fc83']).mode('lab')(percent);


### PR DESCRIPTION
<img width="834" alt="screen shot 2017-11-14 at 10 25 44 pm" src="https://user-images.githubusercontent.com/14918664/32820528-18a37f44-c98c-11e7-97b9-298c8f143065.png">
Lines with more tests are colored darker.  The values are normalized based on the maximum number of tests.
try: http://localhost:3000/file?revision=a0334f789772&path=/accessible/atk/Platform.cpp