### PR TITLE
Use async methods instead of promises

### DIFF
--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -15,11 +15,12 @@ export default class FileViewerContainer extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      /* app status */
       appError: undefined,
-      fetchStatus: {
-        sourceCode: false,
-        testCoverage: false,
-      },
+      srcFetchStatus: undefined,
+      covFetchstatus: undefined,
+      selectedLine: undefined,
+      /* app data */
       parsedFile: [],
       coverage: {
         coveredLines: [],
@@ -28,7 +29,6 @@ export default class FileViewerContainer extends Component {
         testsPerHitLine: [],
         testsPerMissLine: [],
       },
-      selectedLine: undefined,
     };
     this.setSelectedLine = this.setSelectedLine.bind(this);
     /* get revision and path parameters from URL */
@@ -42,20 +42,9 @@ export default class FileViewerContainer extends Component {
     }
     this.revision = parsedQuery.revision;
     this.path = parsedQuery.path;
-  }
 
-  componentDidMount() {
-    /* Fetch source code from hg */
-    FetchAPI.getRawFile(this.revision, this.path)
-      .then((text) => {
-        const fetchStatus = this.state.fetchStatus;
-        fetchStatus.sourceCode = true;
-        this.setState({ parsedFile: text.split('\n'), fetchStatus });
-      })
-    ;
-
-    /* Fetch coverages from ActiveData */
-    FetchAPI.query({
+    // ActiveData Query
+    this.query = {
       from: 'coverage',
       where: {
         and: [
@@ -65,14 +54,41 @@ export default class FileViewerContainer extends Component {
       },
       limit: 1000,
       format: 'list',
-    })
-      .then((data) => {
-        this.parseCoverage(data.data);
-      });
+    };
+  }
+
+  async componentDidMount() {
+    await this.fetchData();
   }
 
   setSelectedLine(selectedLineNumber) {
     this.setState({ selectedLine: selectedLineNumber });
+  }
+
+  async fetchData() {
+    /* Fetch source code from hg */
+    try {
+      const text = await FetchAPI.getRawFile(this.revision, this.path);
+      this.setState({ parsedFile: text.split('\n'), srcFetchStatus: true });
+    } catch (error) {
+      console.error(error);
+      this.setState({
+        appError: 'We did not manage to fetch source file from hg.mozilla',
+        srcFetchStatus: false,
+      });
+    }
+    /* Fetch coverages from ActiveData */
+    try {
+      const activeData = await FetchAPI.query(this.query);
+      this.parseCoverage(activeData.data);
+      this.setState({ covFetchstatus: true });
+    } catch (error) {
+      console.error(error);
+      this.setState({
+        appError: 'We did not manage to fetch test coverage from ActiveData',
+        covFetchstatus: false,
+      });
+    }
   }
 
   /* Parse coverage data */
@@ -104,10 +120,7 @@ export default class FileViewerContainer extends Component {
       });
     });
 
-    const fetchStatus = this.state.fetchStatus;
-    fetchStatus.testCoverage = true;
     this.setState({
-      fetchStatus,
       coverage: {
         coveredLines: _.uniq(covered),
         uncoveredLines: _.uniq(uncovered),
@@ -119,7 +132,7 @@ export default class FileViewerContainer extends Component {
   }
 
   render() {
-    const { appError, fetchStatus, parsedFile, coverage, selectedLine } = this.state;
+    const { appError, srcFetchStatus, covFetchstatus, parsedFile, coverage, selectedLine } = this.state;
 
     return (
       <div>
@@ -128,7 +141,8 @@ export default class FileViewerContainer extends Component {
             revision={this.revision}
             path={this.path}
             appError={appError}
-            fetchStatus={fetchStatus}
+            srcFetchStatus={srcFetchStatus}
+            covFetchstatus={covFetchstatus}
           />
           <FileViewer
             parsedFile={parsedFile}
@@ -201,19 +215,26 @@ const Line = ({ lineNumber, lineText, coverage, selectedLine, onLineClick }) => 
 };
 
 /* This component contains metadata of the file */
-const FileViewerMeta = ({ revision, path, appError, fetchStatus }) => {
+const FileViewerMeta = ({ revision, path, appError, srcFetchStatus, covFetchstatus }) => {
   const showStatus = (label, status) => {
-    const msg = status ? <span>&#x2714;</span> : 'Fetching...';
+    let msg = 'Fetching...';
+    if (status === true) {
+      msg = <span>&#x2714;</span>; // heavy check mark
+    } else if (status === false) {
+      msg = <span>&#x2716;</span>; // heavy multiplication x
+    }
     return (<li className="file-meta-li">{label}: {msg}</li>);
   };
+
+  console.log(appError);
 
   return (
     <div>
       <div className="file-meta-center">
         <div className="file-meta-status">
           <ul className="file-meta-ul">
-            { showStatus('Source code', fetchStatus.sourceCode) }
-            { showStatus('Coverage', fetchStatus.testCoverage) }
+            { showStatus('Source code', srcFetchStatus) }
+            { showStatus('Coverage', covFetchstatus) }
           </ul>
         </div>
         <div className="file-meta-title">File Coverage</div>

--- a/src/style.css
+++ b/src/style.css
@@ -193,6 +193,9 @@ pre { margin: 0; }
 	font-weight: 400;
 	padding: 0.3em 0.8em;
 }
+.error_message {
+	color: red;
+}
 
 .file-view {
 	display: inline-block;


### PR DESCRIPTION
1. Use async methods instead of promises, refer to Issue #38 
2. Save http requests failure information in the ```appError```, and show it on ```FileViewerMeta``` component. (Catch throwed fetching error in the ```fetchData``` async function)