### PR TITLE
Issue #31: Make a facade for logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chroma-js": "^1.3.4",
     "form-serialize": "^0.7.2",
     "lodash": "^4.17.4",
+    "mustache": "^2.3.0",
     "parse-diff": "^0.4.0",
     "prop-types": "^15.6.0",
     "query-string": "^5.0.1",

--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import * as FetchAPI from '../utils/fetch_data';
 import * as Color from '../utils/color';
+import * as Log from '../utils/log';
 import { TestsSideViewer, CoveragePercentageViewer } from './fileviewercov';
 
 const queryString = require('query-string');

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,11 +1,37 @@
-export const note = params => console.log(params);
+const Mustache = require('mustache');
 
-export const info = params => console.info(params);
+const DEBUG = true;
 
-export const debug = params => console.debug(params);
+const validateTemplate = (template) => {
+  if (typeof template !== 'string') {
+    throw Error(`Template: ${template} has to be a string`);
+  }
+};
 
-export const warn = params => console.warn(params);
+export const note = (template, params) => {
+  try {
+    validateTemplate(template);
+    console.log(Mustache.render(template, params));
+  } catch (err) {
+    throw Error(`Problem logging: ${err}`);
+  }
+};
 
-export const error = params => console.error(params);
+export const error = (template, params) => {
+  try {
+    validateTemplate(template);
+    console.error(Mustache.render(template, params));
+  } catch (err) {
+    throw Error(`Problem logging: ${err}`);
+  }
+};
 
-
+export const debug = (value) => {
+  try {
+    if (DEBUG) {
+      console.log(value);
+    }
+  } catch (err) {
+    throw Error(`Problem logging: ${err}`);
+  }
+};

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,0 +1,11 @@
+export const note = params => console.log(params);
+
+export const info = params => console.info(params);
+
+export const debug = params => console.debug(params);
+
+export const warn = params => console.warn(params);
+
+export const error = params => console.error(params);
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,6 +4366,10 @@ multicast-dns@^6.0.1:
     dns-packet "^1.0.1"
     thunky "^0.1.0"
 
+mustache@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"


### PR DESCRIPTION
This is a simple implementation of a logging facade, but also didn't want to complicate something that was working.  I tried to implement it with the mustache library but it seems to only work with strings, e.g. I can't do Log.note(data) where data is the object returned from the coverage fetch call.
