### PR TITLE
Issue #43: pack the status variables

### DIFF
--- a/src/components/fileviewer.js
+++ b/src/components/fileviewer.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import * as FetchAPI from '../utils/fetch_data';
 import * as Color from '../utils/color';
 import * as Log from '../utils/log';
+import {recursiveExtend} from '../utils/map';
 import { TestsSideViewer, CoveragePercentageViewer } from './fileviewercov';
 
 const queryString = require('query-string');
@@ -66,26 +67,25 @@ export default class FileViewerContainer extends Component {
   async getSourceCode(revision = this.revision, path = this.path) {
     try {
       const text = await FetchAPI.getRawFile(revision, path);
-      this.setState(prevState => ({
-        status: {
-          fetch: {
-            source: true,
-            coverage: prevState.status.fetch.coverage,
-          },
+      this.setState(prevState => recursiveExtend(
+        {
+          status: {fetch: {source: true}},
+          parsedFile: text.split('\n')
+
         },
-        parsedFile: text.split('\n'),
-      }));
+        prevState
+      ));
     } catch (error) {
       console.error(error);
-      this.setState(prevState => ({
-        status: {
-          app: 'We did not manage to fetch source file from hg.mozilla',
-          fetch: {
-            source: false,
-            coverage: prevState.status.fetch.coverage,
-          },
+      this.setState(prevState => recursiveExtend(
+        {
+          status: {
+            app: 'We did not manage to fetch source file from hg.mozilla',
+            fetch: {source: false}
+          }
         },
-      }));
+        prevState,
+      ));
     }
   }
 
@@ -103,26 +103,24 @@ export default class FileViewerContainer extends Component {
         limit: 1000,
         format: 'list',
       });
-      this.setState(prevState => ({
-        status: {
-          fetch: {
-            source: prevState.status.fetch.source,
-            coverage: true,
-          },
+      this.setState(prevState => recursiveExtend(
+        {
+          status: {fetch: {coverage: true,},},
+          coverage: this.parseCoverage(activeData.data),
         },
-        coverage: this.parseCoverage(activeData.data),
-      }));
+        prevState
+      ));
     } catch (error) {
       console.error(error);
-      this.setState(prevState => ({
-        status: {
-          app: 'We did not manage to fetch test coverage from ActiveData',
-          fetch: {
-            source: prevState.status.fetch.source,
-            coverage: false,
+      this.setState(prevState => recursiveExtend(
+        {
+          status: {
+            app: 'We did not manage to fetch test coverage from ActiveData',
+            fetch: {coverage: false}
           },
         },
-      }));
+        prevState
+      ));
     }
   }
 

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -1,0 +1,50 @@
+const isMap = (val) => {
+  if (val === null) { return false;}
+  return (typeof val == 'object')
+};
+
+
+/**
+ * IF dest[k]==undefined THEN ASSIGN arguments[i][k]
+ * @param dest - the object to be updated (use null to fill a new object)
+ * @param sources - objects with properties to update dest with (if not already set)
+ * @returns `dest` recursively updated by sources
+ */
+export const recursiveExtend = (dest, ...sources) => {
+  function _setDefault(dest, source, path) {
+    let keys = Object.keys(source);
+    for (let k = 0; k < keys.length; k++) {
+      let key = keys[k];
+      let value = dest[key];
+      if (value == null) {
+        dest[key] = source[key];
+      } else if (!isMap(value)) {
+        // do nothing
+      } else if (path.indexOf(value) != -1) {
+        // do nothing
+      } else {
+        dest[key] = _setDefault(value, source[key], path.concat([value]));
+      }
+    }
+    return dest;
+  }
+
+  for (let source of sources){
+    if (source === undefined) {
+      // do nothing
+    } else if (dest == null) {
+      if (isMap(source)) {
+        return _setDefault({}, source, []);
+      } else {
+        dest = source;
+        break;
+      }
+    } else if (isMap(dest)) {
+      return _setDefault(dest, source, []);
+    } else {
+      break;
+    }
+  }
+  return dest;
+};
+

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -16,11 +16,11 @@ export const recursiveExtend = (dest, ...sources) => {
     for (let k = 0; k < keys.length; k++) {
       let key = keys[k];
       let value = dest[key];
-      if (value == null) {
+      if (value === null) {
         dest[key] = source[key];
       } else if (!isMap(value)) {
         // do nothing
-      } else if (path.indexOf(value) != -1) {
+      } else if (path.indexOf(value) !== -1) {
         // do nothing
       } else {
         dest[key] = _setDefault(value, source[key], path.concat([value]));
@@ -32,7 +32,7 @@ export const recursiveExtend = (dest, ...sources) => {
   for (let source of sources){
     if (source === undefined) {
       // do nothing
-    } else if (dest == null) {
+    } else if (dest === null) {
       if (isMap(source)) {
         return _setDefault({}, source, []);
       } else {


### PR DESCRIPTION
http://localhost:3000/file?revision=b828f7a6c2bf&path=/accessible/atk/Platform.cpp

Not sure if this is overkill, e.g. both source and coverage in the fetch object have to be set:
```
      this.setState(prevState => ({
        status: {
          fetch: {
            source: prevState.status.fetch.source,
            coverage: true,
          },
        },
        coverage: this.parseCoverage(activeData.data),
```
if only coverage is set, then source is overwritten with undefined (from true in the previous state).

Please let me know if there is a better alternative 
